### PR TITLE
Fix publish scripts remote to taxowalk directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# bulksense
+# taxowalk
 
-bulksense classifies free-form product descriptions into the [Shopify product taxonomy](https://github.com/Shopify/product-taxonomy). It incrementally traverses the taxonomy by prompting OpenAI's `gpt-5-mini` model with the candidate categories that exist at each level until a leaf node (or "none of these") is selected.
+taxowalk classifies free-form product descriptions into the [Shopify product taxonomy](https://github.com/Shopify/product-taxonomy). It incrementally traverses the taxonomy by prompting OpenAI's `gpt-5-mini` model with the candidate categories that exist at each level until a leaf node (or "none of these") is selected.
 
 ## Features
 
@@ -17,7 +17,7 @@ bulksense classifies free-form product descriptions into the [Shopify product ta
 ### From source
 
 ```bash
-go build ./cmd/bulksense
+go build ./cmd/taxowalk
 ```
 
 ### Debian/Ubuntu package
@@ -25,9 +25,9 @@ go build ./cmd/bulksense
 Pull requests automatically build a `.deb` using `scripts/build_deb.sh`. Release builds publish to an apt repository hosted at `http://packages.industrial-linguistics.com/shopify/`. After a release is deployed, install it with:
 
 ```bash
-echo "deb [trusted=yes] http://packages.industrial-linguistics.com/shopify/apt stable main" | sudo tee /etc/apt/sources.list.d/bulksense.list
+echo "deb [trusted=yes] http://packages.industrial-linguistics.com/shopify/apt stable main" | sudo tee /etc/apt/sources.list.d/taxowalk.list
 sudo apt update
-sudo apt install bulksense
+sudo apt install taxowalk
 ```
 
 ### macOS and Windows builds
@@ -42,7 +42,7 @@ The resulting archives are uploaded by the workflow to the deployment host via `
 ## Usage
 
 ```bash
-bulksense [flags] [product description]
+taxowalk [flags] [product description]
 ```
 
 ### Flags
@@ -57,8 +57,8 @@ The command prints the selected taxonomy `full_name` followed by its canonical I
 ### Examples
 
 ```bash
-bulksense "Handmade leather tote bag"
-cat product.txt | bulksense --stdin
+taxowalk "Handmade leather tote bag"
+cat product.txt | taxowalk --stdin
 ```
 
 ## Development
@@ -66,14 +66,14 @@ cat product.txt | bulksense --stdin
 - `go test ./...` runs the unit test suite. Integration tests that require OpenAI are skipped unless `OPENAI_API_KEY` is set.
 - `scripts/build_deb.sh` builds a Debian package in `dist/deb/` without uploading it.
 - `scripts/build_macos.sh` and `scripts/build_windows.ps1` cross-compile for the respective platforms; these scripts are invoked only by release workflows.
-- `scripts/publish_release.sh` (used by the release workflow) builds all packages, assembles the apt repository metadata, and deploys the artifacts to `shopify@merah.cassia.ifost.org.au` via `rsync` using the `DEPLOYMENT_SSH_KEY` secret.
+- `scripts/publish_release.sh` (used by the release workflow) builds all packages, assembles the apt repository metadata, and deploys the artifacts to `taxowalk@merah.cassia.ifost.org.au` via `rsync` using the `DEPLOYMENT_SSH_KEY` secret.
 
 The `VERSION` file **must** be updated whenever a change may alter the executable or any installation package. Continuous integration checks ensure packages build before merging.
 
 ## Documentation
 
-- Linux/macOS man page: `docs/bulksense.1`
-- Windows help page: `docs/bulksense-help.txt`
+- Linux/macOS man page: `docs/taxowalk.1`
+- Windows help page: `docs/taxowalk-help.txt`
 
 ## Security
 

--- a/cmd/taxowalk/main.go
+++ b/cmd/taxowalk/main.go
@@ -12,16 +12,16 @@ import (
 	"strings"
 	"time"
 
-	"bulksense/internal/classifier"
-	"bulksense/internal/llm"
-	"bulksense/internal/taxonomy"
+	"taxowalk/internal/classifier"
+	"taxowalk/internal/llm"
+	"taxowalk/internal/taxonomy"
 )
 
 const defaultTaxonomyURL = "https://raw.githubusercontent.com/Shopify/product-taxonomy/refs/heads/main/dist/en/taxonomy.json"
 
 func main() {
 	if err := run(); err != nil {
-		fmt.Fprintln(os.Stderr, "bulksense:", err)
+		fmt.Fprintln(os.Stderr, "taxowalk:", err)
 		os.Exit(1)
 	}
 }
@@ -39,7 +39,7 @@ func run() error {
 	flag.StringVar(&taxonomyURL, "taxonomy-url", defaultTaxonomyURL, "URL or file path for the Shopify taxonomy JSON")
 	flag.StringVar(&baseURL, "openai-base-url", "", "override the OpenAI API base URL")
 	flag.Usage = func() {
-		fmt.Fprintf(flag.CommandLine.Output(), "bulksense - classify products into the Shopify taxonomy\n\n")
+		fmt.Fprintf(flag.CommandLine.Output(), "taxowalk - classify products into the Shopify taxonomy\n\n")
 		fmt.Fprintf(flag.CommandLine.Output(), "Usage: %s [flags] [product description]\n\n", os.Args[0])
 		fmt.Fprintf(flag.CommandLine.Output(), "Flags:\n")
 		flag.PrintDefaults()

--- a/docs/taxowalk-help.txt
+++ b/docs/taxowalk-help.txt
@@ -1,14 +1,14 @@
-BULKSENSE(1)
+TAXOWALK(1)
 ===========
 
 NAME
-    bulksense - classify product descriptions into the Shopify taxonomy
+    taxowalk - classify product descriptions into the Shopify taxonomy
 
 SYNOPSIS
-    bulksense [options] [description ...]
+    taxowalk [options] [description ...]
 
 DESCRIPTION
-    bulksense uses the OpenAI gpt-5-mini model to identify the most suitable
+    taxowalk uses the OpenAI gpt-5-mini model to identify the most suitable
     Shopify taxonomy node for a product description. The tool walks the
     taxonomy tree by repeatedly offering the model a list of candidate
     categories until a terminal node is reached.
@@ -18,7 +18,7 @@ OPTIONS
         Read the product description from standard input. Input must be piped.
 
     --openai-key KEY
-        Provide the OpenAI API key explicitly. If omitted, bulksense uses the
+        Provide the OpenAI API key explicitly. If omitted, taxowalk uses the
         OPENAI_API_KEY environment variable or the file %USERPROFILE%\.openai.key.
 
     --openai-base-url URL
@@ -30,8 +30,8 @@ OPTIONS
         official Shopify taxonomy feed.
 
 EXAMPLES
-    bulksense "Handmade leather tote bag"
-    type description.txt | bulksense --stdin
+    taxowalk "Handmade leather tote bag"
+    type description.txt | taxowalk --stdin
 
 FILES
     %USERPROFILE%\.openai.key

--- a/docs/taxowalk.1
+++ b/docs/taxowalk.1
@@ -1,12 +1,12 @@
-.TH BULKSENSE 1 "March 2025" "bulksense" "User Commands"
+.TH TAXOWALK 1 "March 2025" "taxowalk" "User Commands"
 .SH NAME
-bulksense \- classify product descriptions into the Shopify taxonomy
+taxowalk \- classify product descriptions into the Shopify taxonomy
 .SH SYNOPSIS
-.B bulksense
+.B taxowalk
 .RI [ options ]
 .RI [ description ... ]
 .SH DESCRIPTION
-.B bulksense
+.B taxowalk
 reads a product description from the command line or standard input and
 uses the OpenAI \fBgpt-5-mini\fR model to traverse the Shopify product taxonomy.
 The tool iteratively narrows down the most appropriate taxonomy node by offering
@@ -38,13 +38,13 @@ An error occurred.
 Classify a product description provided as command line text:
 .PP
 .EX
-$ bulksense "Handmade leather tote bag"
+$ taxowalk "Handmade leather tote bag"
 .EX
 .PP
 Read the description from standard input:
 .PP
 .EX
-$ cat product.txt | bulksense --stdin
+$ cat product.txt | taxowalk --stdin
 .EX
 .SH FILES
 .TP

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module bulksense
+module taxowalk
 
 go 1.22
 

--- a/internal/classifier/classifier.go
+++ b/internal/classifier/classifier.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"strings"
 
-	"bulksense/internal/llm"
-	"bulksense/internal/taxonomy"
+	"taxowalk/internal/llm"
+	"taxowalk/internal/taxonomy"
 )
 
 type Classifier struct {

--- a/internal/classifier/classifier_test.go
+++ b/internal/classifier/classifier_test.go
@@ -5,8 +5,8 @@ import (
 	"errors"
 	"testing"
 
-	"bulksense/internal/llm"
-	"bulksense/internal/taxonomy"
+	"taxowalk/internal/llm"
+	"taxowalk/internal/taxonomy"
 )
 
 type mockModel struct {

--- a/scripts/build_deb.sh
+++ b/scripts/build_deb.sh
@@ -12,27 +12,27 @@ CONTROL_DIR="$BUILD_DIR/DEBIAN"
 rm -rf "$BUILD_DIR"
 mkdir -p "$BIN_DIR" "$MAN_DIR" "$CONTROL_DIR" "$DIST_DIR"
 
-GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" -o "$BIN_DIR/bulksense" "$ROOT_DIR/cmd/bulksense"
+GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" -o "$BIN_DIR/taxowalk" "$ROOT_DIR/cmd/taxowalk"
 
-install -m 0644 "$ROOT_DIR/docs/bulksense.1" "$MAN_DIR/bulksense.1"
-gzip -f "$MAN_DIR/bulksense.1"
+install -m 0644 "$ROOT_DIR/docs/taxowalk.1" "$MAN_DIR/taxowalk.1"
+gzip -f "$MAN_DIR/taxowalk.1"
 
 cat > "$CONTROL_DIR/control" <<CONTROL
-Package: bulksense
+Package: taxowalk
 Version: $VERSION
 Section: utils
 Priority: optional
 Architecture: amd64
 Maintainer: Industrial Linguistics <packages@industrial-linguistics.com>
 Description: Shopify taxonomy classifier powered by OpenAI
- bulksense classifies product descriptions into the Shopify taxonomy by
+ taxowalk classifies product descriptions into the Shopify taxonomy by
  iteratively querying the gpt-5-mini model.
 CONTROL
 
 chmod 0755 "$BUILD_DIR/usr"
 chmod -R go-w "$BUILD_DIR/usr/share/man"
 
-OUTPUT="$DIST_DIR/bulksense_${VERSION}_amd64.deb"
+OUTPUT="$DIST_DIR/taxowalk_${VERSION}_amd64.deb"
 
 dpkg-deb --build "$BUILD_DIR" "$OUTPUT"
 

--- a/scripts/build_macos.sh
+++ b/scripts/build_macos.sh
@@ -10,14 +10,14 @@ rm -rf "$WORK_DIR"
 mkdir -p "$WORK_DIR" "$DIST_DIR"
 
 for arch in amd64 arm64; do
-    BIN_NAME="bulksense"
+    BIN_NAME="taxowalk"
     OUT_BIN="$WORK_DIR/${BIN_NAME}-${arch}"
-    GOOS=darwin GOARCH=$arch CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" -o "$OUT_BIN" "$ROOT_DIR/cmd/bulksense"
+    GOOS=darwin GOARCH=$arch CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" -o "$OUT_BIN" "$ROOT_DIR/cmd/taxowalk"
     PKG_DIR="$WORK_DIR/package-$arch"
     mkdir -p "$PKG_DIR/usr/local/bin" "$PKG_DIR/usr/local/share/man/man1"
     install -m 0755 "$OUT_BIN" "$PKG_DIR/usr/local/bin/$BIN_NAME"
-    install -m 0644 "$ROOT_DIR/docs/bulksense.1" "$PKG_DIR/usr/local/share/man/man1/bulksense.1"
-    tarball="$DIST_DIR/bulksense_${VERSION}_darwin_${arch}.tar.gz"
+    install -m 0644 "$ROOT_DIR/docs/taxowalk.1" "$PKG_DIR/usr/local/share/man/man1/taxowalk.1"
+    tarball="$DIST_DIR/taxowalk_${VERSION}_darwin_${arch}.tar.gz"
     (cd "$PKG_DIR" && tar -czf "$tarball" .)
     echo "Built $tarball"
     rm -rf "$PKG_DIR"

--- a/scripts/build_windows.ps1
+++ b/scripts/build_windows.ps1
@@ -18,11 +18,11 @@ $env:GOOS = 'windows'
 $env:GOARCH = 'amd64'
 $env:CGO_ENABLED = '0'
 
-$binary = Join-Path $Build 'bulksense.exe'
-go build -trimpath -ldflags "-s -w" -o $binary (Join-Path $Root 'cmd/bulksense')
+$binary = Join-Path $Build 'taxowalk.exe'
+go build -trimpath -ldflags "-s -w" -o $binary (Join-Path $Root 'cmd/taxowalk')
 
-$helpSource = Join-Path $Root 'docs/bulksense-help.txt'
-$zipPath = Join-Path $Dist ("bulksense_{0}_windows_amd64.zip" -f $Version)
+$helpSource = Join-Path $Root 'docs/taxowalk-help.txt'
+$zipPath = Join-Path $Dist ("taxowalk_{0}_windows_amd64.zip" -f $Version)
 
 Compress-Archive -Path $binary, $helpSource -DestinationPath $zipPath -Force
 

--- a/scripts/publish_debian.sh
+++ b/scripts/publish_debian.sh
@@ -8,8 +8,8 @@ VERSION=$(cat "$ROOT_DIR/VERSION")
 
 APT_ROOT="$ROOT_DIR/build/apt"
 rm -rf "$APT_ROOT"
-mkdir -p "$APT_ROOT/pool/main/b/bulksense" "$APT_ROOT/dists/stable/main/binary-amd64"
-cp "$ROOT_DIR/dist/deb/bulksense_${VERSION}_amd64.deb" "$APT_ROOT/pool/main/b/bulksense/"
+mkdir -p "$APT_ROOT/pool/main/t/taxowalk" "$APT_ROOT/dists/stable/main/binary-amd64"
+cp "$ROOT_DIR/dist/deb/taxowalk_${VERSION}_amd64.deb" "$APT_ROOT/pool/main/t/taxowalk/"
 
 dpkg-scanpackages "$APT_ROOT/pool" > "$APT_ROOT/dists/stable/main/binary-amd64/Packages"
 gzip -kf "$APT_ROOT/dists/stable/main/binary-amd64/Packages"
@@ -19,7 +19,7 @@ Suite: stable
 Codename: stable
 Components: main
 Architectures: amd64
-Description: bulksense apt repository
+Description: taxowalk apt repository
 RELEASE
 
 if [[ -z "${DEPLOYMENT_SSH_KEY:-}" ]]; then
@@ -32,6 +32,6 @@ trap 'rm -f "$KEY_FILE"' EXIT
 printf '%s' "$DEPLOYMENT_SSH_KEY" > "$KEY_FILE"
 chmod 600 "$KEY_FILE"
 
-REMOTE="shopify@merah.cassia.ifost.org.au:/var/www/vhosts/packages.industrial-linguistics.com/htdocs/shopify"
+REMOTE="taxowalk@merah.cassia.ifost.org.au:/var/www/vhosts/packages.industrial-linguistics.com/htdocs/taxowalk"
 
 rsync -avz -e "ssh -i $KEY_FILE -o StrictHostKeyChecking=no" "$APT_ROOT/" "$REMOTE/apt/"

--- a/scripts/publish_release.sh
+++ b/scripts/publish_release.sh
@@ -18,7 +18,7 @@ trap 'rm -f "$KEY_FILE"' EXIT
 printf '%s' "$DEPLOYMENT_SSH_KEY" > "$KEY_FILE"
 chmod 600 "$KEY_FILE"
 
-REMOTE="shopify@merah.cassia.ifost.org.au:/var/www/vhosts/packages.industrial-linguistics.com/htdocs/shopify"
+REMOTE="taxowalk@merah.cassia.ifost.org.au:/var/www/vhosts/packages.industrial-linguistics.com/htdocs/taxowalk"
 
 rsync -avz -e "ssh -i $KEY_FILE -o StrictHostKeyChecking=no" "$ROOT_DIR/dist/macos/" "$REMOTE/macos/"
 rsync -avz -e "ssh -i $KEY_FILE -o StrictHostKeyChecking=no" "$ROOT_DIR/dist/windows/" "$REMOTE/windows/"


### PR DESCRIPTION
## Summary
- update publish scripts to deploy artifacts under the htdocs/taxowalk path on merah

## Testing
- `go test ./...` *(fails: command timed out in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de36689bd88325b8ddbfd4431660b5