### PR TITLE
Install apt-ftparchive in Debian workflow

### DIFF
--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Install apt-ftparchive
+        run: sudo apt-get update && sudo apt-get install -y apt-utils
       - name: Set up Go
         uses: actions/setup-go@v5
         with:


### PR DESCRIPTION
## Summary
- ensure the Debian publish workflow installs apt-ftparchive via apt-utils before running the publish script

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de7c9a8e348325a1e09e06dd92efb9