### PR TITLE
Add debug logging option to taxowalk

### DIFF
--- a/cmd/taxowalk/main.go
+++ b/cmd/taxowalk/main.go
@@ -20,6 +20,8 @@ import (
 
 const defaultTaxonomyURL = "https://raw.githubusercontent.com/Shopify/product-taxonomy/refs/heads/main/dist/en/taxonomy.json"
 
+var debugEnabled bool
+
 func main() {
 	if err := run(); err != nil {
 		fmt.Fprintln(os.Stderr, "taxowalk:", err)
@@ -41,6 +43,7 @@ func run() error {
 	flag.StringVar(&taxonomyURL, "taxonomy-url", defaultTaxonomyURL, "URL or file path for the Shopify taxonomy JSON")
 	flag.StringVar(&baseURL, "openai-base-url", "", "override the OpenAI API base URL")
 	flag.StringVar(&dbPath, "history-db", "", "SQLite database path to track token usage history")
+	flag.BoolVar(&debugEnabled, "debug", false, "enable verbose debug logging to standard error")
 	flag.Usage = func() {
 		fmt.Fprintf(flag.CommandLine.Output(), "taxowalk - classify products into the Shopify taxonomy\n\n")
 		fmt.Fprintf(flag.CommandLine.Output(), "Usage: %s [flags] [product description]\n\n", os.Args[0])
@@ -49,36 +52,52 @@ func run() error {
 	}
 	flag.Parse()
 
+	debugf("Arguments: %s", strings.Join(os.Args[1:], " "))
+
 	description, err := loadDescription(useStdin, flag.Args())
 	if err != nil {
 		return err
 	}
 
+	debugf("Product description (%d chars)", len(description))
+
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
+	start := time.Now()
+	debugf("Fetching taxonomy from %s", taxonomyURL)
 	tax, err := taxonomy.Fetch(ctx, taxonomyURL)
 	if err != nil {
 		return fmt.Errorf("failed to load taxonomy: %w", err)
 	}
+	debugf("Fetched taxonomy in %s (%d root categories)", time.Since(start), len(tax.Roots))
 
 	apiKey, err := resolveAPIKey(apiKeyFlag)
 	if err != nil {
 		return err
 	}
+	debugf("Resolved API key")
 
 	var opts []llm.OptionFunc
 	if baseURL != "" {
 		opts = append(opts, llm.WithBaseURL(baseURL))
+		debugf("Using custom OpenAI base URL: %s", baseURL)
 	}
 	model, err := llm.NewOpenAIModel(apiKey, opts...)
 	if err != nil {
 		return err
 	}
+	debugf("Initialised OpenAI model")
 
 	clf, err := classifier.New(model, tax)
 	if err != nil {
 		return err
+	}
+
+	if debugEnabled {
+		clf.SetDebugLogger(func(format string, args ...interface{}) {
+			debugf("classifier: "+format, args...)
+		})
 	}
 
 	node, err := clf.Classify(ctx, description)
@@ -87,8 +106,10 @@ func run() error {
 	}
 
 	usage := clf.Usage()
+	debugf("Token usage - prompt: %d, completion: %d, total: %d", usage.PromptTokens, usage.CompletionTokens, usage.TotalTokens)
 
 	if dbPath != "" {
+		debugf("Recording classification history in %s", dbPath)
 		db, err := history.Open(dbPath)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: failed to open history database: %v\n", err)
@@ -103,21 +124,26 @@ func run() error {
 			if err := db.RecordClassification(description, categoryName, categoryID,
 				usage.PromptTokens, usage.CompletionTokens, usage.TotalTokens); err != nil {
 				fmt.Fprintf(os.Stderr, "Warning: failed to record classification: %v\n", err)
+			} else {
+				debugf("Classification history recorded")
 			}
 		}
 	}
 
 	if node == nil {
+		debugf("Classifier returned nil node")
 		fmt.Println("No matching Shopify category found.")
 		return nil
 	}
 
+	debugf("Classification result: %s (%s)", node.FullName, node.ID)
 	fmt.Printf("%s\n%s\n", node.FullName, node.ID)
 	return nil
 }
 
 func loadDescription(useStdin bool, args []string) (string, error) {
 	if useStdin {
+		debugf("Reading product description from standard input")
 		info, err := os.Stdin.Stat()
 		if err != nil {
 			return "", err
@@ -134,14 +160,17 @@ func loadDescription(useStdin bool, args []string) (string, error) {
 	if len(args) == 0 {
 		return "", errors.New("no product description provided")
 	}
+	debugf("Using product description from command line arguments (%d parts)", len(args))
 	return strings.TrimSpace(strings.Join(args, " ")), nil
 }
 
 func resolveAPIKey(explicit string) (string, error) {
 	if strings.TrimSpace(explicit) != "" {
+		debugf("Using API key provided via --openai-key flag")
 		return strings.TrimSpace(explicit), nil
 	}
 	if key := strings.TrimSpace(os.Getenv("OPENAI_API_KEY")); key != "" {
+		debugf("Using API key from OPENAI_API_KEY environment variable")
 		return key, nil
 	}
 	home, err := os.UserHomeDir()
@@ -149,6 +178,7 @@ func resolveAPIKey(explicit string) (string, error) {
 		return "", fmt.Errorf("unable to determine home directory: %w", err)
 	}
 	path := filepath.Join(home, ".openai.key")
+	debugf("Reading API key from %s", path)
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return "", fmt.Errorf("failed to read API key from %s: %w", path, err)
@@ -158,4 +188,11 @@ func resolveAPIKey(explicit string) (string, error) {
 		return "", fmt.Errorf("API key file %s is empty", path)
 	}
 	return key, nil
+}
+
+func debugf(format string, args ...interface{}) {
+	if !debugEnabled {
+		return
+	}
+	fmt.Fprintf(os.Stderr, "[debug] "+format+"\n", args...)
 }

--- a/internal/classifier/classifier.go
+++ b/internal/classifier/classifier.go
@@ -14,6 +14,7 @@ type Classifier struct {
 	model      llm.Model
 	taxonomy   *taxonomy.Taxonomy
 	totalUsage llm.Usage
+	debugf     func(format string, args ...interface{})
 }
 
 func New(model llm.Model, tax *taxonomy.Taxonomy) (*Classifier, error) {
@@ -26,6 +27,16 @@ func New(model llm.Model, tax *taxonomy.Taxonomy) (*Classifier, error) {
 	return &Classifier{model: model, taxonomy: tax}, nil
 }
 
+func (c *Classifier) SetDebugLogger(fn func(format string, args ...interface{})) {
+	c.debugf = fn
+}
+
+func (c *Classifier) logf(format string, args ...interface{}) {
+	if c != nil && c.debugf != nil {
+		c.debugf(format, args...)
+	}
+}
+
 func (c *Classifier) Classify(ctx context.Context, description string) (*taxonomy.Node, error) {
 	if strings.TrimSpace(description) == "" {
 		return nil, errors.New("description is empty")
@@ -36,7 +47,14 @@ func (c *Classifier) Classify(ctx context.Context, description string) (*taxonom
 	options := c.taxonomy.Roots
 	var path []string
 
+	c.logf("Starting classification with %d root options", len(options))
+
 	for len(options) > 0 {
+		if len(path) > 0 {
+			c.logf("Current path: %s", strings.Join(path, " > "))
+		} else {
+			c.logf("Current path: <root>")
+		}
 		prompt := llm.Prompt{
 			Description: description,
 			Path:        append([]string{}, path...),
@@ -46,10 +64,20 @@ func (c *Classifier) Classify(ctx context.Context, description string) (*taxonom
 			prompt.Options[i] = llm.Option{Name: opt.Name, FullName: opt.FullName, ID: opt.ID}
 		}
 
+		optionSummaries := make([]string, len(options))
+		for i, opt := range options {
+			optionSummaries[i] = fmt.Sprintf("%s (%s)", opt.FullName, opt.ID)
+		}
+		c.logf("Candidate options: %s", strings.Join(optionSummaries, "; "))
+
+		c.logf("Requesting model choice")
 		result, err := c.model.ChooseOption(ctx, prompt)
 		if err != nil {
 			return nil, err
 		}
+
+		c.logf("Model returned choice %q (prompt tokens: %d, completion tokens: %d, total: %d)",
+			result.Choice, result.Usage.PromptTokens, result.Usage.CompletionTokens, result.Usage.TotalTokens)
 
 		c.totalUsage.PromptTokens += result.Usage.PromptTokens
 		c.totalUsage.CompletionTokens += result.Usage.CompletionTokens
@@ -57,6 +85,7 @@ func (c *Classifier) Classify(ctx context.Context, description string) (*taxonom
 
 		normalized := strings.TrimSpace(result.Choice)
 		if strings.EqualFold(normalized, "none of these") {
+			c.logf("Model selected 'none of these'; stopping classification")
 			break
 		}
 		var next *taxonomy.Node
@@ -67,14 +96,21 @@ func (c *Classifier) Classify(ctx context.Context, description string) (*taxonom
 			}
 		}
 		if next == nil {
+			c.logf("Model choice %q did not match any candidate option", result.Choice)
 			return current, fmt.Errorf("model selected unknown option %q", result.Choice)
 		}
 
 		current = next
 		path = append(path, current.Name)
 		options = current.Children
+		c.logf("Descending to %s (%s) with %d child options", current.FullName, current.ID, len(options))
 	}
 
+	if current == nil {
+		c.logf("No matching category identified")
+	} else {
+		c.logf("Final classification: %s (%s)", current.FullName, current.ID)
+	}
 	return current, nil
 }
 


### PR DESCRIPTION
## Summary
- add a --debug flag to the taxowalk CLI that enables verbose stderr logging across the execution path
- wire the classifier to surface detailed step-by-step logging when debug mode is active

## Testing
- timeout 30 go test ./internal/...

------
https://chatgpt.com/codex/tasks/task_e_68e0788b06dc8325891d490be9d06252